### PR TITLE
fix 受け取る時間がUTCであることを前提に変更

### DIFF
--- a/components/ConvertTime.vue
+++ b/components/ConvertTime.vue
@@ -3,14 +3,22 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue"
+import Vue from "vue";
 export default Vue.extend({
-  props: { time: { type: String, default: "" }  },
+  props: {
+    time: {
+      type: String,
+      default: "",
+    },
+  },
   computed: {
+    /**受け取ったGMT文字列を表示する時間文字列に変更
+     *  @param {void}
+     * this.time - "Mon, 01 Feb 2021 01:18:32 GMT"
+     *  @return {string} - 2021/2/1 10:18
+     */
     convertJapaneseTime(): string {
-      let date: Date = new Date(this.time);
-      date.setHours(date.getHours() - 9);
-      return date.toLocaleString("ja").slice(0, -3);
+      return new Date(this.time).toLocaleString("ja").slice(0, -3);
     },
   },
 });


### PR DESCRIPTION
これまでローカルのバックエンドの環境に合わせ、
**実態は日本時間だがGMT扱いになっている時間**を正しく表示するようになっていたが、
**実態はUTCでGMT扱いになっている時間**を正しく表示するように修正。